### PR TITLE
Fixed: Unresolved for Akka Library

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,12 +5,11 @@ version := "1.0"
 scalaVersion := "2.11.8"
 
 libraryDependencies ++= Seq(
-  "com.typesafe.akka" %% "akka-actor" % "2.4-SNAPSHOT",
+  "com.typesafe.akka" %% "akka-actor" % "2.4.20",
   "com.typesafe.akka" %% "akka-http-core" % "10.0.0",
-  "com.typesafe.akka" %% "akka-contrib" % "2.4-SNAPSHOT",
-  "com.typesafe.akka" %% "akka-testkit" % "2.4-SNAPSHOT" % "test",
+  "com.typesafe.akka" %% "akka-contrib" % "2.4.20",
+  "com.typesafe.akka" %% "akka-testkit" % "2.4.20" % "test",
   "org.scalatest" %% "scalatest" % "3.0.1" % "test",
   "net.liftweb" %% "lift-json" % "2.6.2"
 )
 
-resolvers += "Akka Snapshot Repository" at "http://repo.akka.io/snapshots/"


### PR DESCRIPTION
Since Akka 2.4 reached its EOL on 12/31/2017, the snapshot of 2.4 is no longer provided. (https://akka.io/blog/news/2018/01/11/akka-2.5.9-released-2.4.x-end-of-life)
This is a kind of workaround. Next version (v0.2.0) will support Akka 2.5.